### PR TITLE
feat(next): add download modal

### DIFF
--- a/components/DownloadButton/DownloadButton.js
+++ b/components/DownloadButton/DownloadButton.js
@@ -1,13 +1,26 @@
+import classNames from 'classnames';
+import { string } from 'prop-types';
+
 import styles from './DownloadButton.scss';
 
 const DownloadButton = (props) => (
   <a
-    className={`button ${styles.downloadButton}`}
+    className={classNames('button', styles.downloadButton, props.className)}
     href="https://github.com/nos/client/releases"
     target="_blank"
   >
-    Download Now
+    {props.label}
   </a>
 );
+
+DownloadButton.propTypes = {
+  className: string,
+  label: string
+};
+
+DownloadButton.defaultProps = {
+  className: null,
+  label: 'Download Now'
+};
 
 export default DownloadButton;

--- a/components/DownloadButton/DownloadButton.scss
+++ b/components/DownloadButton/DownloadButton.scss
@@ -13,7 +13,7 @@
     padding: 13px 40px 13px 64px;
     background: url('/static/nos-circle-flat.svg') 10px center no-repeat,
     linear-gradient(180deg, #FFFFFF 22.5%, #F6F4FA 100%);
-    color: #443562;
+    color: $dark-gray;
   }
 
   &:hover {

--- a/components/DownloadModal/DownloadModal.js
+++ b/components/DownloadModal/DownloadModal.js
@@ -1,0 +1,45 @@
+import { string, func } from 'prop-types';
+import { noop } from 'lodash';
+
+import Modal from '../Modal';
+import DownloadButton from '../DownloadButton';
+import styles from './DownloadModal.scss';
+
+export default class DownloadModal extends React.Component {
+  static propTypes = {
+    target: string.isRequired,
+    onClose: func
+  }
+
+  static defaultProps = {
+    onClose: noop
+  }
+
+  render() {
+    return (
+      <Modal className={styles.downloadModal} renderHeader={this.renderHeader}>
+        <div className={styles.content}>
+          <div className={styles.appIcon} />
+          <div className={styles.message}>This application can only be opened in nOS Client</div>
+        </div>
+        <DownloadButton className={styles.download} label="Click here to download now" />
+      </Modal>
+    );
+  }
+
+  renderHeader = () => {
+    return (
+      <div className={styles.header}>
+        <span className={styles.title}>
+          You are trying to open <strong>{this.props.target}</strong>
+        </span>
+        <span
+          className={styles.close}
+          tabIndex="0"
+          role="button"
+          onClick={this.props.onClose}
+        />
+      </div>
+    );
+  }
+}

--- a/components/DownloadModal/DownloadModal.scss
+++ b/components/DownloadModal/DownloadModal.scss
@@ -1,0 +1,57 @@
+.downloadModal {
+  width: 460px;
+  border-radius: 8px;
+  background: #FFF;
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 52px;
+    padding: 0 20px;
+    border-radius: 8px 8px 0 0;
+    background: #EEEBF3;
+
+    .title {
+      flex: 1 1 auto;
+    }
+
+    .close {
+      flex: 0 0 auto;
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      background: url('/static/modal-close.svg');
+      cursor: pointer;
+    }
+  }
+
+  .content {
+    display: flex;
+    align-items: center;
+    justify-content: stretch;
+    margin: 40px 20px;
+
+    .appIcon {
+      flex: 0 0 auto;
+      width: 112px;
+      height: 112px;
+      margin-right: 20px;
+      background: url('/static/nos-app-icon.svg');
+    }
+
+    .message {
+      flex: 1 1 auto;
+      font-weight: bold;
+      font-size: 20px;
+      line-height: 29px;
+      color: $dark-gray;
+    }
+  }
+
+  .download {
+    display: block;
+    margin: 0 20px 20px;
+    text-align: center;
+  }
+}

--- a/components/DownloadModal/index.js
+++ b/components/DownloadModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './DownloadModal';

--- a/components/Modal/Modal.js
+++ b/components/Modal/Modal.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import classNames from 'classnames';
+import { string, func, node } from 'prop-types';
+import { noop } from 'lodash';
+
+import Portal from '../Portal';
+import styles from './Modal.scss';
+
+export default class Modal extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    children: node,
+    renderHeader: func,
+    renderFooter: func
+  };
+
+  static defaultProps = {
+    className: null,
+    children: null,
+    renderHeader: noop,
+    renderFooter: noop
+  };
+
+  render() {
+    return (
+      <Portal className={styles.portal}>
+        <div className={styles.backdrop} />
+        <div className={classNames(styles.modal, this.props.className)}>
+          {this.props.renderHeader()}
+          {this.props.children}
+          {this.props.renderFooter()}
+        </div>
+      </Portal>
+    );
+  }
+}

--- a/components/Modal/Modal.scss
+++ b/components/Modal/Modal.scss
@@ -1,0 +1,31 @@
+.portal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  z-index: 100;
+
+  .backdrop {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(68, 53, 98, 0.9);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+  }
+
+  .modal {
+    position: relative;
+    border-radius: 4px;
+    background-color: #fff;
+    box-shadow: 0 2px 6px rgba(30, 27, 82, 0.12);
+  }
+}

--- a/components/Modal/index.js
+++ b/components/Modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Modal';

--- a/components/Portal/Portal.js
+++ b/components/Portal/Portal.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { string, node, func } from 'prop-types';
+import { noop } from 'lodash';
+
+export default class Portal extends React.PureComponent {
+  static propTypes = {
+    className: string,
+    children: node,
+    onClickOutside: func
+  };
+
+  static defaultProps = {
+    className: null,
+    children: null,
+    onClickOutside: noop
+  };
+
+  constructor(props) {
+    super(props);
+    this.el = document.createElement('div');
+    this.el.className = this.props.className;
+  }
+
+  componentDidMount() {
+    document.body.appendChild(this.el);
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.el);
+  }
+
+  render() {
+    return ReactDOM.createPortal(this.props.children, this.el);
+  }
+
+  handleClickOutside = () => {
+    this.props.onClickOutside();
+  }
+}

--- a/components/Portal/index.js
+++ b/components/Portal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Portal';

--- a/components/Showcase/Card/Card.js
+++ b/components/Showcase/Card/Card.js
@@ -1,36 +1,69 @@
 import classNames from 'classnames';
 import { bool, string } from 'prop-types';
+import { isUndefined } from 'lodash';
 
+import DownloadModal from '../../DownloadModal';
 import styles from './Card.scss';
 
-const Card = (props) => (
-  <div className={classNames(styles.card, styles[props.color], { [styles.primary]: props.primary })}>
-    <div className={styles.main}>
-      <div className={styles.overlay}>
-        <h3>{props.name}</h3>
-        <p className={styles.large}>{props.children}</p>
+export default class Card extends React.Component {
+  static propTypes = {
+    primary: bool,
+    color: string,
+    name: string.isRequired,
+    image: string.isRequired,
+    url: string.isRequired,
+    code: string.isRequired
+  }
+
+  static defaultProps = {
+    primary: false,
+    color: null
+  }
+
+  state = {
+    target: null
+  }
+
+  render() {
+    return (
+      <div className={classNames(styles.card, styles[this.props.color], { [styles.primary]: this.props.primary })}>
+        <div className={styles.main}>
+          <div className={styles.overlay}>
+            <h3>{this.props.name}</h3>
+            <p className={styles.large}>{this.props.children}</p>
+          </div>
+          <img src={this.props.image} alt={this.props.name} />
+        </div>
+        <div className={styles.meta}>
+          <a href={this.props.url} target="_blank" onClick={this.handleOpen}>{this.props.url}</a>
+          <a href={this.props.code} target="_blank">Code</a>
+        </div>
+        {this.renderModal()}
       </div>
-      <img src={props.image} />
-    </div>
-    <div className={styles.meta}>
-      <a href={props.url} target="_blank">{props.url}</a>
-      <a href={props.code} target="_blank">Code</a>
-    </div>
-  </div>
-);
+    );
+  }
 
-Card.propTypes = {
-  primary: bool,
-  color: string,
-  name: string.isRequired,
-  image: string.isRequired,
-  url: string.isRequired,
-  code: string.isRequired
-};
+  renderModal = () => {
+    if (!this.state.target) {
+      return null;
+    }
 
-Card.defaultProps = {
-  primary: false,
-  color: null
-};
+    return (
+      <DownloadModal
+        target={this.state.target}
+        onClose={this.handleClose}
+      />
+    );
+  }
 
-export default Card;
+  handleOpen = (event) => {
+    if (isUndefined(window.NOS)) {
+      event.preventDefault();
+      this.setState({ target: event.target.href });
+    }
+  }
+
+  handleClose = () => {
+    this.setState({ target: null });
+  }
+}

--- a/static/modal-close.svg
+++ b/static/modal-close.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1.5 0L0 1.5L4.5 6L0 10.5L1.5 12L6 7.5L10.5 12L12 10.5L7.5 6L12 1.5L10.5 0L6 4.5L1.5 0Z" fill="#8F84A6"/>
+</svg>

--- a/static/nos-app-icon.svg
+++ b/static/nos-app-icon.svg
@@ -1,0 +1,53 @@
+<svg width="112" height="112" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<g filter="url(#filter0_dd)">
+<circle cx="56" cy="56" r="50.3125" fill="url(#paint0_linear)"/>
+<circle cx="56" cy="56" r="50.3125" fill="white" fill-opacity="0.4"/>
+</g>
+<g filter="url(#filter1_di)">
+<circle cx="56" cy="56" r="37.1875" transform="rotate(90 56 56)" stroke="url(#paint1_linear)" stroke-width="12.25"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_dd" x="-1.3125" y="-0.4375" width="114.625" height="114.625" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="0.875"/>
+<feGaussianBlur stdDeviation="3.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="1.3125"/>
+<feGaussianBlur stdDeviation="2.1875"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_di" x="11.8125" y="12.6875" width="88.375" height="88.375" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="0.875"/>
+<feGaussianBlur stdDeviation="0.4375"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1.3125"/>
+<feGaussianBlur stdDeviation="1.42188"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.352941 0 0 0 0 0.729412 0 0 0 0 0.278431 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<linearGradient id="paint0_linear" x1="56" y1="5.6875" x2="56" y2="106.312" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="#ECFAFF"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="56" y1="12.6875" x2="56" y2="99.3125" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5ABA47"/>
+<stop offset="1" stop-color="#B6D433"/>
+</linearGradient>
+<clipPath id="clip0">
+<rect width="112" height="112" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
This forces the download modal to open when clicking `nos` protocol links outside of nOS Client.

Closes #9.

<img width="1182" alt="screen shot 2018-10-19 at 9 05 19 pm" src="https://user-images.githubusercontent.com/169093/47250170-c79fac00-d3e2-11e8-93d5-42b1db61701e.png">
