### PR TITLE
feat(whitepaper): redirect from old route

### DIFF
--- a/helpers/redirect.js
+++ b/helpers/redirect.js
@@ -1,0 +1,12 @@
+import Router from 'next/router'
+
+export default function redirect(context, location) {
+  const { res } = context;
+
+  if (res) {
+    res.writeHead(302, { Location: location });
+    res.end();
+  } else {
+    Router.push(location);
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ module.exports = withSass({
   // static site export config
   exportPathMap: () => ({
     '/': { page: '/' },
-    '/privacy': { page: '/privacy' }
+    '/privacy': { page: '/privacy' },
+    '/whitepaper.pdf': { page: '/whitepaper.pdf' }
   })
 });

--- a/pages/whitepaper.pdf.js
+++ b/pages/whitepaper.pdf.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import redirect from '../helpers/redirect';
+
+export default class extends React.Component {
+  static async getInitialProps(context) {
+    redirect(context, '/static/whitepaper.pdf');
+    return {};
+  }
+}


### PR DESCRIPTION
This adds a redirect so that anyone accessing https://nos.io/whitepaper.pdf will be redirected to https://nos.io/static/whitepaper.pdf.