### PR TITLE
chore(header): fix spacing issues for responsive layout & privacy page

### DIFF
--- a/components/Hero/Hero.scss
+++ b/components/Hero/Hero.scss
@@ -6,7 +6,11 @@
   position: relative;
 
   @media screen and (max-width: $break-medium) {
-    padding-top: 48px;
+    padding-top: 192px;
+  }
+
+  @media screen and (max-width: $break-small) {
+    padding-top: 144px;
   }
 
   .large {

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -11,12 +11,12 @@ import './Layout.scss';
 export default class Layout extends React.Component {
   static propTypes = {
     title: string,
-    ico: bool
+    fixed: bool
   }
 
   static defaultProps = {
     title: 'nOS - Operating System for the Decentralized Internet',
-    ico: false
+    fixed: false
   }
 
   state = {
@@ -42,7 +42,7 @@ export default class Layout extends React.Component {
           <title>{this.props.title}</title>
         </Head>
 
-        <Navigation ico={this.props.ico} />
+        <Navigation fixed={this.props.fixed} />
         {this.props.children}
         <Footer />
         {this.renderBanner()}

--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -5,7 +5,7 @@ import { bool } from 'prop-types';
 import styles from './Navigation.scss';
 
 const Navigation = (props) => (
-  <div className={classNames(styles.navigation, { [styles.icoActive]: props.ico })}>
+  <div className={classNames(styles.navigation, { [styles.fixed]: props.fixed })}>
     <Link href="/"><a className={styles.logo} /></Link>
     <nav className={styles.navItems}>
         <Link href="/#hero"><a>Download</a></Link>
@@ -19,11 +19,11 @@ const Navigation = (props) => (
 );
 
 Navigation.propTypes = {
-  ico: bool
+  fixed: bool
 };
 
 Navigation.defaultProps = {
-  ico: false
+  fixed: false
 };
 
 export default Navigation;

--- a/components/Navigation/Navigation.scss
+++ b/components/Navigation/Navigation.scss
@@ -3,13 +3,17 @@
   padding: 24px 24px 0;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 24px;
   font-size: 14px;
-  position: absolute;
-  z-index: 2;
 
   @media screen and (max-width: $break-medium) {
     flex-direction: column;
     justify-content: center;
+  }
+
+  &.fixed {
+    position: absolute;
+    z-index: 2;
   }
 
   .logo {
@@ -33,10 +37,9 @@
       display: flex;
     }
 
-    @media screen and (max-width: 600px) {
+    @media screen and (max-width: $break-small) {
       display: none;
     }
-
 
     a {
       margin-left: 32px;

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,7 +9,7 @@ import Newsletter from '../components/Newsletter';
 // import Demo from '../components/Demo';
 
 const Index = () => (
-  <Layout>
+  <Layout fixed>
     <Hero />
     <Partners />
     <Features />


### PR DESCRIPTION
On the privacy page, this ensures the content doesn't overlap with the navigation header.

On the home page, this ensures that the content doesn't overlap with the navigation header when the browser narrows (responsive layout).